### PR TITLE
WIP: Adds api to help measure elements

### DIFF
--- a/demo/lit-element.html
+++ b/demo/lit-element.html
@@ -34,22 +34,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       static get properties() {
         return {
           nug: {},
-          zot: {},
           foo: {},
           bar: {},
           whales: {type: Number},
           fooBar: {converter: {fromAttribute: parseInt, toAttribute: (value) => value + '-attr'}, reflect: true}
         }
       }
-
-      // a custom getter/setter can be created to customize property processing
-      get zot() { return this.getAttribute('zot'); }
-
-      set zot(value) {
-        this.setAttribute('zot', value);
-        this.invalidate();
-      }
-
 
       constructor() {
         super();

--- a/src/lib/patch-layout.ts
+++ b/src/lib/patch-layout.ts
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {elementsPendingUpdate, UpdatingElement} from './updating-element.js';
+
+/**
+ * **EXPERIMENTAL**
+ * Loading this module redefines properties that provoke a
+ * layout and style calculation on *all DOM elements*. These properties are
+ * are redefined such that they provoke any contained UpdatingElements to
+ * synchronously update before returning the native property value. This ensures
+ * that these properties will always return the expected value, even if
+ * contained UpdatingElements are pending update.
+ */
+
+const contains = (container: Element, element: UpdatingElement) => {
+  while (element && container !== element) {
+    element = (element as any)._updateParent || element.parentNode  || (element as any).host;
+  }
+  return container === element;
+};
+
+/**
+ * Commits updates within the given element's subtree.
+ */
+export const commit = (element: Element) => {
+  elementsPendingUpdate.forEach((updatingElement) => {
+    if (contains(element, updatingElement)) {
+      updatingElement.flushUpdate();
+    }
+  });
+};
+
+const protos = [Element.prototype, HTMLElement.prototype];
+
+const getProto = (prop: PropertyKey) => {
+  return protos.find((proto) => proto.hasOwnProperty(prop));
+};
+
+const redefineProperty = (prop: PropertyKey, isMethod?: boolean) => {
+  const proto = getProto(prop);
+  if (!proto) {
+    return;
+  }
+  const descriptor = Object.getOwnPropertyDescriptor(proto, prop);
+  if (!descriptor!.configurable) {
+    return;
+  }
+  const native = isMethod ? descriptor!.value : descriptor!.get!;
+  const wrapped = function(this: Element) {
+    commit(this);
+    return native.call(this);
+  };
+  if (isMethod) {
+    descriptor!.value = wrapped;
+  } else {
+    descriptor!.get = wrapped;
+  }
+  Object.defineProperty(proto, prop, descriptor!);
+};
+
+// methods
+[
+  'getClientRects',
+  'getBoundingClientRect',
+].forEach((prop) => redefineProperty(prop, true));
+
+
+
+// getters
+[
+  'offsetLeft',
+  'offsetTop',
+  'offsetWidth',
+  'offsetHeight',
+  'offsetParent',
+  'clientLeft',
+  'clientWidth',
+  'clientHeight',
+  'scrollLeft',
+  'scrollTop',
+  'scrollWidth',
+  'scrollHeight',
+  'innerText',
+  'outerText',
+].forEach((prop) => redefineProperty(prop));

--- a/src/lib/patch-layout.ts
+++ b/src/lib/patch-layout.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {elementsPendingUpdate, UpdatingElement} from './updating-element.js';
+import {UpdatingElement} from './updating-element.js';
 
 /**
  * **EXPERIMENTAL**
@@ -23,24 +23,6 @@ import {elementsPendingUpdate, UpdatingElement} from './updating-element.js';
  * that these properties will always return the expected value, even if
  * contained UpdatingElements are pending update.
  */
-
-const contains = (container: Element, element: UpdatingElement) => {
-  while (element && container !== element) {
-    element = (element as any)._updateParent || element.parentNode  || (element as any).host;
-  }
-  return container === element;
-};
-
-/**
- * Commits updates within the given element's subtree.
- */
-export const commit = (element: Element) => {
-  elementsPendingUpdate.forEach((updatingElement) => {
-    if (contains(element, updatingElement)) {
-      updatingElement.flushUpdate();
-    }
-  });
-};
 
 const protos = [Element.prototype, HTMLElement.prototype];
 
@@ -59,7 +41,7 @@ const redefineProperty = (prop: PropertyKey, isMethod?: boolean) => {
   }
   const native = isMethod ? descriptor!.value : descriptor!.get!;
   const wrapped = function(this: Element) {
-    commit(this);
+    UpdatingElement.flushUpdates();
     return native.call(this);
   };
   if (isMethod) {

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -13,7 +13,7 @@
  */
 
 import {property} from '../../lib/decorators.js';
-import {UpdatingElement} from '../../lib/updating-element.js';
+import {UpdatingElement, PropertyValues} from '../../lib/updating-element.js';
 import {generateElementName} from '../test-helpers.js';
 
 const assert = chai.assert;
@@ -32,103 +32,249 @@ suite('UpdatingElement', () => {
     }
   });
 
-  test('can override performUpdate()', async () => {
-    class A extends UpdatingElement {
-      performUpdateCalled = false;
-      updateCalled = false;
+  suite('scheduling', () => {
 
-      async performUpdate() {
-        this.performUpdateCalled = true;
-        await new Promise((r) => setTimeout(r, 10));
-        await super.performUpdate();
+    test('can override performUpdate()', async () => {
+      class A extends UpdatingElement {
+        performUpdateCalled = false;
+        updateCalled = false;
+
+        async performUpdate() {
+          this.performUpdateCalled = true;
+          await new Promise((r) => setTimeout(r, 10));
+          await super.performUpdate();
+        }
+
+        update(changedProperties: Map<PropertyKey, unknown>) {
+          this.updateCalled = true;
+          super.update(changedProperties);
+        }
       }
+      customElements.define(generateElementName(), A);
 
-      update(changedProperties: Map<PropertyKey, unknown>) {
-        this.updateCalled = true;
-        super.update(changedProperties);
+      const a = new A();
+      container.appendChild(a);
+
+      // update is not called synchronously
+      assert.isFalse(a.updateCalled);
+
+      // update is not called after a microtask
+      await 0;
+      assert.isFalse(a.updateCalled);
+
+      // update is not called after short timeout
+      await new Promise((r) => setTimeout(r));
+      assert.isFalse(a.updateCalled);
+
+      // update is called after long timeout
+      await new Promise((r) => setTimeout(r, 20));
+      assert.isTrue(a.updateCalled);
+    });
+
+    test('overriding performUpdate() allows nested invalidations', async () => {
+      class A extends UpdatingElement {
+        performUpdateCalledCount = 0;
+        updatedCalledCount = 0;
+
+        async performUpdate() {
+          this.performUpdateCalledCount++;
+          await new Promise((r) => setTimeout(r));
+          super.performUpdate();
+        }
+
+        updated(_changedProperties: Map<PropertyKey, unknown>) {
+          this.updatedCalledCount++;
+          // trigger a nested invalidation just once
+          if (this.updatedCalledCount === 1) {
+            this.requestUpdate();
+          }
+        }
       }
-    }
-    customElements.define(generateElementName(), A);
+      customElements.define(generateElementName(), A);
 
-    const a = new A();
-    container.appendChild(a);
+      const a = new A();
+      container.appendChild(a);
+      assert.equal(a.updatedCalledCount, 0);
 
-    // update is not called synchronously
-    assert.isFalse(a.updateCalled);
+      const updateComplete1 = a.updateComplete;
+      await updateComplete1;
+      assert.equal(a.updatedCalledCount, 1);
+      assert.equal(a.performUpdateCalledCount, 1);
 
-    // update is not called after a microtask
-    await 0;
-    assert.isFalse(a.updateCalled);
+      const updateComplete2 = a.updateComplete;
+      assert.notStrictEqual(updateComplete1, updateComplete2);
 
-    // update is not called after short timeout
-    await new Promise((r) => setTimeout(r));
-    assert.isFalse(a.updateCalled);
+      await updateComplete2;
+      assert.equal(a.updatedCalledCount, 2);
+      assert.equal(a.performUpdateCalledCount, 2);
+    });
 
-    // update is called after long timeout
-    await new Promise((r) => setTimeout(r, 20));
-    assert.isTrue(a.updateCalled);
+    test('update does not occur before element is connected', async () => {
+      class A extends UpdatingElement {
+
+        updatedCalledCount = 0;
+
+        @property() foo = 5;
+
+        constructor() {
+          super();
+          this.requestUpdate();
+        }
+
+        updated(_changedProperties: Map<PropertyKey, unknown>) {
+          this.updatedCalledCount++;
+        }
+      }
+      customElements.define(generateElementName(), A);
+      const a = new A();
+      await new Promise((r) => setTimeout(r, 20));
+      assert.equal(a.updatedCalledCount, 0);
+      container.appendChild(a);
+      await a.updateComplete;
+      assert.equal(a.updatedCalledCount, 1);
+    });
+
   });
 
-  test('overriding performUpdate() allows nested invalidations', async () => {
-    class A extends UpdatingElement {
-      performUpdateCalledCount = 0;
-      updatedCalledCount = 0;
+  suite('layout', () => {
+    class Base extends UpdatingElement {
 
-      async performUpdate() {
-        this.performUpdateCalledCount++;
-        await new Promise((r) => setTimeout(r));
-        super.performUpdate();
+      @property()
+      size = '';
+
+      content: HTMLElement|undefined;
+
+      _rendered = false;
+
+      render() {
+        this.style.display = 'block';
+        this.content = document.createElement('div');
+        this.renderRoot!.appendChild(this.content);
       }
 
-      updated(_changedProperties: Map<PropertyKey, unknown>) {
-        this.updatedCalledCount++;
-        // trigger a nested invalidation just once
-        if (this.updatedCalledCount === 1) {
-          this.requestUpdate();
+      update(changedProperties: PropertyValues) {
+        super.update(changedProperties);
+        if (!this._rendered) {
+          this.render();
+        }
+        if (changedProperties.has('size')) {
+          this.content!.style.height = this.size;
         }
       }
     }
-    customElements.define(generateElementName(), A);
+    customElements.define('update-base', Base);
 
-    const a = new A();
-    container.appendChild(a);
-    assert.equal(a.updatedCalledCount, 0);
+    class Sub extends Base {
 
-    const updateComplete1 = a.updateComplete;
-    await updateComplete1;
-    assert.equal(a.updatedCalledCount, 1);
-    assert.equal(a.performUpdateCalledCount, 1);
+      base1: HTMLElement|undefined;
+      base2: HTMLElement|undefined;
 
-    const updateComplete2 = a.updateComplete;
-    assert.notStrictEqual(updateComplete1, updateComplete2);
-
-    await updateComplete2;
-    assert.equal(a.updatedCalledCount, 2);
-    assert.equal(a.performUpdateCalledCount, 2);
-  });
-
-  test('update does not occur before element is connected', async () => {
-    class A extends UpdatingElement {
-
-      updatedCalledCount = 0;
-
-      @property() foo = 5;
-
-      constructor() {
-        super();
-        this.requestUpdate();
-      }
-
-      updated(_changedProperties: Map<PropertyKey, unknown>) {
-        this.updatedCalledCount++;
+      render() {
+        super.render();
+        this.base1 = document.createElement('update-base');
+        this.renderRoot!.appendChild(this.base1);
+        this.base2 = document.createElement('update-base');
+        this.renderRoot!.appendChild(this.base2);
       }
     }
-    customElements.define(generateElementName(), A);
-    const a = new A();
-    await new Promise((r) => setTimeout(r, 20));
-    assert.equal(a.updatedCalledCount, 0);
-    container.appendChild(a);
-    await a.updateComplete;
-    assert.equal(a.updatedCalledCount, 1);
+
+    customElements.define('update-sub', Sub);
+
+    class Container extends Base {
+
+      sub1: HTMLElement|undefined;
+      sub2: HTMLElement|undefined;
+
+      render() {
+        super.render();
+        this.sub1 = document.createElement('update-sub');
+        this.renderRoot!.appendChild(this.sub1);
+        this.sub2 = document.createElement('update-sub');
+        this.renderRoot!.appendChild(this.sub2);
+      }
+    }
+
+    customElements.define('update-container', Container);
+
+    test('`updateSubtreeComplete` awaits entire update subtree', async () => {
+      const el = new Container();
+      container.appendChild(el);
+      await el.updateSubtreeComplete;
+      assert.ok(el.sub1);
+      assert.ok(el.sub2);
+      assert.ok((el.sub1! as Sub).base1);
+      assert.ok((el.sub1! as Sub).base2);
+      assert.ok((el.sub2! as Sub).base1);
+      assert.ok((el.sub2! as Sub).base2);
+      assert.ok(((el.sub1! as Sub).base1 as Base).content);
+      assert.ok(((el.sub1! as Sub).base2 as Base).content);
+      assert.ok(((el.sub2! as Sub).base1 as Base).content);
+      assert.ok(((el.sub2! as Sub).base2 as Base).content);
+      el.size = '2px';
+      (el.sub1 as Base).size = '2px';
+      (el.sub2 as Base).size = '2px';
+      ((el.sub1 as Sub).base1 as Base).size = '2px';
+      ((el.sub1 as Sub).base2 as Base).size = '2px';
+      ((el.sub2 as Sub).base1 as Base).size = '2px';
+      ((el.sub2 as Sub).base2 as Base).size = '2px';
+      await el.updateSubtreeComplete;
+      assert.equal(el.offsetHeight, 14);
+    });
+
+    test('`flushUpdate` forces entire element update subtree to update', async () => {
+      const el = new Container();
+      container.appendChild(el);
+      el.flushUpdate();
+      assert.ok(el.sub1);
+      assert.ok(el.sub2);
+      assert.ok((el.sub1! as Sub).base1);
+      assert.ok((el.sub1! as Sub).base2);
+      assert.ok((el.sub2! as Sub).base1);
+      assert.ok((el.sub2! as Sub).base2);
+      assert.ok(((el.sub1! as Sub).base1 as Base).content);
+      assert.ok(((el.sub1! as Sub).base2 as Base).content);
+      assert.ok(((el.sub2! as Sub).base1 as Base).content);
+      assert.ok(((el.sub2! as Sub).base2 as Base).content);
+      el.size = '2px';
+      (el.sub1 as Base).size = '2px';
+      (el.sub2 as Base).size = '2px';
+      ((el.sub1 as Sub).base1 as Base).size = '2px';
+      ((el.sub1 as Sub).base2 as Base).size = '2px';
+      ((el.sub2 as Sub).base1 as Base).size = '2px';
+      ((el.sub2 as Sub).base2 as Base).size = '2px';
+      el.flushUpdate();
+      assert.equal(el.offsetHeight, 14);
+    });
+
+    test('`flushUpdates` forces entire page to update', async () => {
+      const el1 = new Container();
+      const el2 = new Container();
+      container.appendChild(el1);
+      container.appendChild(el2);
+      UpdatingElement.flushUpdates();
+      const test = (el: Container) => {
+        assert.ok(el.sub1);
+        assert.ok(el.sub2);
+        assert.ok((el.sub1! as Sub).base1);
+        assert.ok((el.sub1! as Sub).base2);
+        assert.ok((el.sub2! as Sub).base1);
+        assert.ok((el.sub2! as Sub).base2);
+        assert.ok(((el.sub1! as Sub).base1 as Base).content);
+        assert.ok(((el.sub1! as Sub).base2 as Base).content);
+        assert.ok(((el.sub2! as Sub).base1 as Base).content);
+        assert.ok(((el.sub2! as Sub).base2 as Base).content);
+        el.size = '2px';
+        (el.sub1 as Base).size = '2px';
+        (el.sub2 as Base).size = '2px';
+        ((el.sub1 as Sub).base1 as Base).size = '2px';
+        ((el.sub1 as Sub).base2 as Base).size = '2px';
+        ((el.sub2 as Sub).base1 as Base).size = '2px';
+        ((el.sub2 as Sub).base2 as Base).size = '2px';
+      };
+      test(el1);
+      test(el2);
+      UpdatingElement.flushUpdates();
+      assert.equal(container.offsetHeight, 28);
+    });
   });
 });


### PR DESCRIPTION
Work in progress, do not merge.

Fixes #365.

* `updateSubtreeComplete` promise: resolves when entire element subtree is updated: wait and then measure.
* `flushUpdate()`: call to flush any pending elements on the element or its subtree: call and then measure.
* `LitElement.flushUpdates()`: call to flush any pending updates for all LitElements: call and then measure element containing updating elements.
* `patch-layout.js`: module which patches native DOM properties so that they flush any pending updates therefore always returning expected results. (load to work with 3rd party libraries that expect to be able to measure synchronously.