### PR TITLE
Update fromAttribute for Arrays and Objects when no valid value is set

### DIFF
--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -151,8 +151,9 @@ export const defaultConverter: ComplexAttributeConverter = {
       case Number:
         return value === null ? null : Number(value);
       case Object:
+        return value === '' ? {} : JSON.parse(value!);
       case Array:
-        return JSON.parse(value!);
+        return value === '' ? [] : JSON.parse(value!);
     }
     return value;
   }


### PR DESCRIPTION
For better understanding on the issue please check #722 

This happens because `JSON.parse('')` will be fired and empty string is not a valid JSON.

My changes make an empty attribute to be converted to an empty array or an empty object what seems the expected behaviour in these cases not breaking internal methods.

### Alternative solution

Change the default value to return `undefined` instead of the initial value as in my current solution.

### Reference Issue
Fixes #722 