### PR TITLE
Prevent creating ShimAdoptedStyleSheets if not instance of TemplateResult

### DIFF
--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -196,15 +196,15 @@ export class LitElement extends UpdatingElement {
     super.update(changedProperties);
     const templateResult = this.render() as unknown;
 
-    if (templateResult instanceof TemplateResult) {
+    if (templateResult instanceof TemplateResult === false) {
       return;
     }
     
     (this.constructor as typeof LitElement)
-          .render(
-              templateResult,
-              this.renderRoot,
-              {scopeName: this.localName, eventContext: this});
+      .render(
+          templateResult,
+          this.renderRoot,
+          {scopeName: this.localName, eventContext: this});
 
     // When native Shadow DOM is used but adoptedStyles are not supported,
     // insert styling after rendering to ensure adoptedStyles have highest

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -199,7 +199,7 @@ export class LitElement extends UpdatingElement {
     if (templateResult instanceof TemplateResult === false) {
       return;
     }
-    
+
     (this.constructor as typeof LitElement)
       .render(
           templateResult as TemplateResult,

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -202,7 +202,7 @@ export class LitElement extends UpdatingElement {
     
     (this.constructor as typeof LitElement)
       .render(
-          templateResult,
+          templateResult as TemplateResult,
           this.renderRoot,
           {scopeName: this.localName, eventContext: this});
 

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -195,13 +195,17 @@ export class LitElement extends UpdatingElement {
   protected update(changedProperties: PropertyValues) {
     super.update(changedProperties);
     const templateResult = this.render() as unknown;
+
     if (templateResult instanceof TemplateResult) {
-      (this.constructor as typeof LitElement)
+      return;
+    }
+    
+    (this.constructor as typeof LitElement)
           .render(
               templateResult,
               this.renderRoot,
               {scopeName: this.localName, eventContext: this});
-    }
+
     // When native Shadow DOM is used but adoptedStyles are not supported,
     // insert styling after rendering to ensure adoptedStyles have highest
     // priority.


### PR DESCRIPTION
Pointing to this issue https://stackoverflow.com/questions/58519848/styles-are-not-applied-to-the-litelement-in-safari-firefox

If `templateResult` was not a TemplateResult instance, the ShimAdoptedStyleSheets were still created.

If `templateResult` becomes an instance of TemplateResult afterwards, ShimAdoptedStyleSheets are not created anymore because _needsShimAdoptedStyleSheets prevents creating them more than once.
