### PR TITLE
Add a "bundle" build target

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "build": "tsc",
     "build:babel-test": "babel src/test/lib/decorators_test.ts --out-file test/lib/decorators-babel_test.js",
+    "bundle": "rollup -c",
     "gen-docs": "typedoc --readme docs/_api/api-readme.md --tsconfig tsconfig_apidoc.json --mode modules --theme docs/_api/theme --excludeNotExported --excludePrivate --ignoreCompilerErrors --exclude '{**/*test*,**/node_modules/**,**/test/**}' --out ./docs/api --gaID UA-39334307-23 src/**/*.ts",
     "test": "npm run build && npm run build:babel-test && wct",
     "checksize": "rollup -c ; rm lit-element.bundled.js",


### PR DESCRIPTION
Adds a supported way to invoke rollup to generate `lit-element.bundled.js` so I don't have to dig it out of `./node_modules/` any more.
