### PR TITLE
Adds `attributeShouldChangeProperty(name, oldValue, value)` protected…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * The value returned by `render` is always rendered, even if it isn't a `TemplateResult`. ([#712](https://github.com/Polymer/lit-element/issues/712)
 
 ### Added
+* Added `attributeShouldChangeProperty(name, oldValue, value)` method to customize the dirty check applied to attribute changes. This adds an opt-in, non-breaking way to address https://github.com/Polymer/lit-element/issues/699.
 * Added `enableUpdating()` to `UpdatingElement` to enable customizing when updating is enabled [#860](https://github.com/Polymer/lit-element/pull/860).
 * Added `queryAssignedNodes(slotName, flatten)` to enable querying assignedNodes for a given slot [#860](https://github.com/Polymer/lit-element/pull/860).
 * Added `getStyles()` to `LitElement` to allow hooks into style gathering for component sets [#866](https://github.com/Polymer/lit-element/pull/866).

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -518,10 +518,14 @@ export abstract class UpdatingElement extends HTMLElement {
   /**
    * Synchronizes property values when attributes change.
    */
-  attributeChangedCallback(name: string, old: string|null, value: string|null) {
-    if (old !== value) {
+  attributeChangedCallback(name: string, old: string|null, value: string|null, namespace: string) {
+    if (this.attributeShouldChangeProperty(name, old, value, namespace)) {
       this._attributeToProperty(name, value);
     }
+  }
+
+  protected attributeShouldChangeProperty(_name: string, old: string|null, value: string|null, _namespace: string|null) {
+    return old !== value;
   }
 
   private _propertyToAttribute(

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -1880,8 +1880,8 @@ suite('UpdatingElement', () => {
       get bar() {
         return this.getAttribute('bar') || 'defaultBar';
       }
-      attributeChangedCallback(name: string, old: string, value: string) {
-        super.attributeChangedCallback(name, old, value);
+      attributeChangedCallback(name: string, old: string, value: string, namespace: string) {
+        super.attributeChangedCallback(name, old, value, namespace);
         this.requestUpdate(name, old);
       }
       update(changedProperties: PropertyValues) {
@@ -1945,14 +1945,14 @@ suite('UpdatingElement', () => {
     await el.updateComplete;
     assert.equal(el._updateCount, 1);
 
-    el.setAttribute('foo', 'foo');;
-    el.setAttribute('bar', 'bar');;
+    el.setAttribute('foo', 'foo');
+    el.setAttribute('bar', 'bar');
     await el.updateComplete;
     assert.equal(el.foo, 'foo');
     assert.equal(el.bar, 'bar');
     assert.equal(el._updateCount, 2);
-    el.setAttribute('foo', 'foo');;
-    el.setAttribute('bar', 'bar');;
+    el.setAttribute('foo', 'foo');
+    el.setAttribute('bar', 'bar');
     await el.updateComplete;
     assert.equal(el._updateCount, 3);
 

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -1922,6 +1922,46 @@ suite('UpdatingElement', () => {
     assert.equal(el._updateCount, 3);
   });
 
+  test('can override `attributeShouldChangeProperty` to see every attribute change', async () => {
+    class E extends UpdatingElement {
+      _updateCount = 0;
+      foo?: string;
+      bar?: string;
+      static get properties() {
+        return {foo: {type: String, hasChanged: () => true}, bar: {type: String, hasChanged: () => true}};
+      }
+      attributeShouldChangeProperty() {
+        return true;
+      }
+      update(changedProperties: PropertyValues) {
+        this._updateCount++;
+        super.update(changedProperties);
+      }
+    }
+    customElements.define(generateElementName(), E);
+
+    const el = new E();
+    container.appendChild(el);
+    await el.updateComplete;
+    assert.equal(el._updateCount, 1);
+
+    el.setAttribute('foo', 'foo');;
+    el.setAttribute('bar', 'bar');;
+    await el.updateComplete;
+    assert.equal(el.foo, 'foo');
+    assert.equal(el.bar, 'bar');
+    assert.equal(el._updateCount, 2);
+    el.setAttribute('foo', 'foo');;
+    el.setAttribute('bar', 'bar');;
+    await el.updateComplete;
+    assert.equal(el._updateCount, 3);
+
+    el.removeAttribute('foo');
+    await el.updateComplete;
+    assert.equal(el.foo, null);
+    assert.equal(el._updateCount, 4);
+  });
+
   test(
       'setting properties in `updated` does trigger update and does not block updateComplete',
       async () => {


### PR DESCRIPTION
… method.

This method allows for customizing the dirty check applied when attribute values change. The default is to avoid setting a corresponding property when an attribute changes and the old and new values are exactly the same. This is being done to address #699. It's done as an opt-in to avoid a breaking change.
