### PR TITLE
Implements _childrenPendingHydration queue to coordinate parent/child hydration

### DIFF
--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -755,7 +755,7 @@ export abstract class UpdatingElement extends HTMLElement {
    * }
    * ```
    */
-  protected performUpdate(): void|Promise<unknown> {
+  performUpdate(noUpdatedCallbacks?: boolean): void|Promise<unknown> {
     // Abort any update if one is not pending when this is called.
     // This can happen if `performUpdate` is called early to "flush"
     // the update.
@@ -783,7 +783,7 @@ export abstract class UpdatingElement extends HTMLElement {
       this._markUpdated();
       throw e;
     }
-    if (shouldUpdate) {
+    if (shouldUpdate && !noUpdatedCallbacks) {
       if (!(this._updateState & STATE_HAS_UPDATED)) {
         this._updateState = this._updateState | STATE_HAS_UPDATED;
         this.firstUpdated(changedProperties);

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -754,8 +754,11 @@ export abstract class UpdatingElement extends HTMLElement {
    *   super.performUpdate();
    * }
    * ```
+   * 
+   * @param runUpdatedCallbacks When `false`, `firstUpdated` and `updated`
+   *   callbacks are not run (defaults to `true`).
    */
-  performUpdate(noUpdatedCallbacks?: boolean): void|Promise<unknown> {
+  protected performUpdate(runUpdatedCallbacks = true): void|Promise<unknown> {
     // Abort any update if one is not pending when this is called.
     // This can happen if `performUpdate` is called early to "flush"
     // the update.
@@ -783,7 +786,7 @@ export abstract class UpdatingElement extends HTMLElement {
       this._markUpdated();
       throw e;
     }
-    if (shouldUpdate && !noUpdatedCallbacks) {
+    if (shouldUpdate && runUpdatedCallbacks) {
       if (!(this._updateState & STATE_HAS_UPDATED)) {
         this._updateState = this._updateState | STATE_HAS_UPDATED;
         this.firstUpdated(changedProperties);

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -336,7 +336,7 @@ export class LitElement extends UpdatingElement {
         (this.constructor as typeof LitElement)
             .hydrate(templateResult, this.renderRoot);
         // Hydrate any children waiting on parent hydration
-        this.renderRoot.querySelectorAll('[defer-hydration]').forEach(el => {
+        this.renderRoot.querySelectorAll('[defer-hydration]').forEach((el) => {
           el.removeAttribute('defer-hydration');
         });
       } else {

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -126,7 +126,7 @@ export class LitElement extends UpdatingElement {
       (result: unknown, container: Element|DocumentFragment,
        options: ShadyRenderOptions) => void = render;
 
-  ssrRenderChildren: IterableIterator<string> | undefined;
+  ssrRenderChildren: IterableIterator<string>|undefined;
 
   /**
    * LitElement detects if it should try to `hydrate` based on whether or not
@@ -143,7 +143,7 @@ export class LitElement extends UpdatingElement {
     return [...super.observedAttributes, 'defer-hydration'];
   }
 
-  attributeChangedCallback(name: string, old: string | null, value: string | null) {
+  attributeChangedCallback(name: string, old: string|null, value: string|null) {
     if (name === 'defer-hydration' && value === null && this._needsHydration) {
       this.connectedCallback();
     } else {


### PR DESCRIPTION
Fixes an issue where children will typically be registered and thus boot up/hydrate bottom-up, before having received its bound hydration state from its parent:
* All child custom elements rendered into a shadow root will have a `defer-hydration` attribute applied
* When an element upgrades, if the `defer-hydration` attribute is applied it will refrain from running its UpdatingElement:connectedCallback() implementation, keeping the element in a non-enabled state and deferring hydration
* After a parent hydrates, it queries for `[defer-hydration]` children in its shadow root and removes those attributes
* When the `defer-hydration` attribute is removed, a child will resume running its `UpdatingElement:connectedCallback()`, thus enabling itself, running its hydration step, and causing the process to recurse.

This change also includes some minimal code necessary for the `element-as-renderer` change in `lit-ssr`:
* Adds a `noUpdatedCallbacks` argument to `performUpdate`, used when running update synchronously during SSR
* Adds the (optional) `ssrRenderChildren` interface to its definition; this will be assigned by `lit-element-renderer`

<!-- Instructions: https://github.com/Polymer/lit-element/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
<!-- Example: Fixes #1234 -->
