### PR TITLE
feat: make banner more apparent

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -474,7 +474,8 @@ article ol li {
 
 .version-banner {
   padding: 0px 20px;
-  border: 1px solid #000;
+  border: 1px solid #f00;
+  background-color: rgba(255, 255, 141, 0.53);
   max-width: 640px;
   display: flex;
   align-items: center;


### PR DESCRIPTION
From this:

![image](https://user-images.githubusercontent.com/5981958/139605272-1a923efa-7afd-4e5b-b3d8-3e9a95ad5cf3.png)


To this:

![image](https://user-images.githubusercontent.com/5981958/139605257-e1e68475-6ed9-432b-b347-5c7576dba15f.png)

a11y contrast checker shows that it's the same a11y rating - there were already problems with blue on white and the rating is not degraded with this bg