### PR TITLE
Add deep links to lit.dev equivalent pages.

### DIFF
--- a/docs/_guide/build.md
+++ b/docs/_guide/build.md
@@ -2,6 +2,7 @@
 layout: guide
 title: Build for production
 slug: build
+lit_dev_path: /docs/tools/production/
 ---
 
 {::options toc_levels="1..3" /}

--- a/docs/_guide/community.md
+++ b/docs/_guide/community.md
@@ -2,6 +2,7 @@
 layout: guide
 title: Community
 slug: community
+lit_dev_path: /docs/tools/publishing/
 ---
 
 {::options toc_levels="1..3" /}

--- a/docs/_guide/decorators.md
+++ b/docs/_guide/decorators.md
@@ -2,6 +2,7 @@
 layout: guide
 title: Using decorators
 slug: decorators
+lit_dev_path: /docs/components/decorators/
 ---
 
 Decorators are special expressions that can alter the behavior of class, class method, and class field declarations. LitElement supplies a set of decorators that reduce the amount of boilerplate code you need to write when defining a component.

--- a/docs/_guide/events.md
+++ b/docs/_guide/events.md
@@ -2,6 +2,7 @@
 layout: guide
 title: Events
 slug: events
+lit_dev_path: /docs/components/events/
 ---
 
 {::options toc_levels="1..3" /}

--- a/docs/_guide/index.md
+++ b/docs/_guide/index.md
@@ -2,6 +2,7 @@
 layout: guide
 title: Introduction
 permalink: /guide
+lit_dev_path: /docs/
 ---
 
 {::options toc_levels="1..3" /}

--- a/docs/_guide/lifecycle.md
+++ b/docs/_guide/lifecycle.md
@@ -2,6 +2,7 @@
 layout: guide
 title: Lifecycle
 slug: lifecycle
+lit_dev_path: /docs/components/lifecycle/
 ---
 
 {::options toc_levels="1..3" /}

--- a/docs/_guide/properties.md
+++ b/docs/_guide/properties.md
@@ -2,6 +2,7 @@
 layout: guide
 title: Properties
 slug: properties
+lit_dev_path: /docs/components/properties/
 ---
 
 {::options toc_levels="1..3" /}

--- a/docs/_guide/publish.md
+++ b/docs/_guide/publish.md
@@ -2,6 +2,7 @@
 layout: guide
 title: Publish an element
 slug: publish
+lit_dev_path: /docs/tools/publishing/
 ---
 
 {::options toc_levels="1..3" /}

--- a/docs/_guide/start.md
+++ b/docs/_guide/start.md
@@ -2,6 +2,7 @@
 layout: guide
 title: Getting Started
 slug: start
+lit_dev_path: /docs/getting-started/
 ---
 
 {::options toc_levels="1..3" /}

--- a/docs/_guide/styles.md
+++ b/docs/_guide/styles.md
@@ -2,6 +2,7 @@
 layout: guide
 title: Styles
 slug: styles
+lit_dev_path: /docs/components/styles/
 ---
 
 {::options toc_levels="1..3" /}

--- a/docs/_guide/templates.md
+++ b/docs/_guide/templates.md
@@ -2,6 +2,7 @@
 layout: guide
 title: Templates
 slug: templates
+lit_dev_path: /docs/components/rendering/
 ---
 
 {::options toc_levels="1..3" /}

--- a/docs/_guide/use.md
+++ b/docs/_guide/use.md
@@ -2,6 +2,7 @@
 layout: guide
 title: Use a component
 slug: use
+lit_dev_path: /docs/
 ---
 
 {::options toc_levels="1..3" /}

--- a/docs/_includes/version-banner.html
+++ b/docs/_includes/version-banner.html
@@ -1,8 +1,7 @@
 <div class="version-banner">
   <img src="/images/flame.svg">
   <p>
-  You're viewing an older version of the Lit documentation (LitElement 2.x).
-  <br>
-  <strong>See <a href="https://lit.dev{{page.lit_dev_path | default ''}}">lit.dev</a> for the latest version.</strong>
+  You're viewing docs for an older version of Lit.<br>
+  <strong>For the current version, visit <a href="https://lit.dev{{page.lit_dev_path | default ''}}">lit.dev</a>.</strong>
   </p>
 </div>

--- a/docs/_includes/version-banner.html
+++ b/docs/_includes/version-banner.html
@@ -1,7 +1,8 @@
 <div class="version-banner">
   <img src="/images/flame.svg">
   <p>
-  LitElement is now part of the Lit library–see the new site at  <a href="https://lit.dev">lit.dev</a>.
-  This site documents LitElement 2.x, not the latest version. 
+  You're viewing an older version of the Lit documentation (LitElement 2.x).
+  <br>
+  <strong>See <a href="https://lit.dev{{page.lit_dev_path | default ''}}">lit.dev</a> for the latest version.</strong>
   </p>
 </div>


### PR DESCRIPTION
Related to https://github,com/lit/lit.dev/issues/471

Staged: https://lit-dev-links-dot-polymer-lit-element.uk.r.appspot.com/guide

Also updated text a bit:

<img width="695" alt="Screen Shot 2021-11-02 at 2 35 38 PM" src="https://user-images.githubusercontent.com/1149422/139955158-6db6538f-fa73-4a91-860e-236960c9af05.png">

